### PR TITLE
update Bouncy Castle PKIX library to JDK 1.8 version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation 'org.xmlunit:xmlunit-core:2.9.1'
     implementation 'org.xmlunit:xmlunit-matchers:2.9.1'
     implementation 'com.github.jknack:handlebars:4.3.1'
-    implementation 'org.bouncycastle:bcpkix-jdk15on:1.77'
+    implementation 'org.bouncycastle:bcpkix-jdk18on:1.77'
 
     // Data Access
     implementation 'software.amazon.awssdk:dynamodb-enhanced:2.20.121'


### PR DESCRIPTION
The e2e test framework is currently unable to build as the project references the 'org.bouncycastle:bcpkix-jdk15on:1.77' artefact which as been replaced by 'org.bouncycastle:bcpkix-jdk18on:1.77' (see https://mvnrepository.com/artifact/org.bouncycastle/bcpkix-jdk15on )

This needs to be updated in order for the project to build successfully. The tests are currently failing in GoCD as a result of this.